### PR TITLE
Correct typo in noncentered double exponential

### DIFF
--- a/src/functions-reference/unbounded_continuous_distributions.Rmd
+++ b/src/functions-reference/unbounded_continuous_distributions.Rmd
@@ -687,7 +687,7 @@ parameterization for the normal distribution, one can write \[ \alpha \sim
 \alpha \sim \mathsf{Normal}(\mu, \sqrt{\alpha}), \] then \[ \beta \sim
 \mathsf{DoubleExponential}(\mu, \sigma ). \] This may be used to code
 a non-centered parameterization by taking \[ \beta^{\text{raw}} \sim
-\mathsf{Normal}(0, 1) \] and defining \[ \beta = \mu + \alpha \,
+\mathsf{Normal}(0, 1) \] and defining \[ \beta = \mu + \sqrt{\alpha} \,
 \beta^{\text{raw}}. \]
 
 


### PR DESCRIPTION
See https://discourse.mc-stan.org/t/mis-understanding-reparameterization-of-the-double-exponential-distribution/32785

#### Submission Checklist

- [ ] Builds locally 
- [ ] New functions marked with `` `r since("VERSION")` ``
- [ ] Declare copyright holder and open-source license: see below

#### Summary

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
